### PR TITLE
Imagr Functions and LaunchDaemonIdentifier

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,9 +30,9 @@ Setting common defaults via a plist, and overriding the version via the command 
 ```bash
  sudo ./first-boot-pkg --plist /Users/grahamgilbert/Desktop/first-boot-config.plist --version 2.3
  ```
- 
+
 ##Configuration plist
- 
+
  ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -47,6 +47,8 @@ Setting common defaults via a plist, and overriding the version via the command 
     <string>package-name.pkg</string>
     <key>Identifier</key>
     <string>com.grahamgilbert.test.pkg</string>
+    <key>LaunchDaemonIdentifier</key>
+    <string>com.grahamgilbert.first-boot-pkg</string>
     <key>Version</key>
     <string>2.4</string>
     <key>Network</key>
@@ -64,6 +66,8 @@ Setting common defaults via a plist, and overriding the version via the command 
 ## Notes
 
 By default, the network retry and sleep count are both set to 10 for a total of 100 seconds. If you would like a smaller delay with a total of 100 seconds, use a RetryCount of 100 and a SleepCount of 1. Note that a smaller SleepCount may result in more log entries.
+
+You can now specify a "LaunchDaemonIdentifier". This will allow you to override the default value of "com.grahamgilbert.first-boot-pkg"
 
 ## Credits
 

--- a/Resources/first-boot
+++ b/Resources/first-boot
@@ -58,6 +58,8 @@ First Boot Package Installer %s
 ######################################################
 ''') % time.strftime("%Y-%m-%d %H:%M:%S"))
     plist_opts = plistlib.readPlist(config_plist)
+    # Detect new network hardware
+    command = "/usr/sbin/networksetup -detectnewhardware"
     if plist_opts.get('Network') == True:
         # Check if the network is up
         while True:

--- a/Resources/first-boot
+++ b/Resources/first-boot
@@ -41,7 +41,9 @@ def cleanup():
     log_path = open(logfile, 'a')
     log.info('No more packages have been found to install, cleaning up.')
     # remove launchdaemon
-    os.remove('/Library/LaunchDaemons/com.grahamgilbert.first-boot-pkg.plist')
+    plist_opts = plistlib.readPlist(config_plist)
+    launchd = os.path.join('/Library/LaunchDaemons/', plist_opts.get('LaunchDaemon'))
+    os.remove(launchd)
     # remove launchagent
     os.remove('/Library/LaunchAgents/se.gu.it.LoginLog.plist')
     # remove loginlog.app
@@ -67,7 +69,6 @@ First Boot Package Installer %s
                 log.info('Network connection is inactive, retrying...')
                 time_limit = time.sleep(plist_opts.get('SleepCount'))
     retry_limit = plist_opts.get('RetryCount')
-
     # if the packages dir isn't empty, loop over them
     if os.listdir(packages_dir):
         # We're installing, wait to see the output
@@ -104,6 +105,7 @@ First Boot Package Installer %s
             all_done()                
     
     # We're done, reboot. Wait 20 seconds so the log window can be read.
+    sleep_time = 20
     time.sleep(sleep_time)
     all_done()
     subprocess.call(['/sbin/reboot'])

--- a/Resources/first-boot
+++ b/Resources/first-boot
@@ -29,8 +29,16 @@ def ip_addresses():
     command = "ifconfig  | grep -E 'inet.[0-9]' | grep -v '127.0.0.1' | awk '{ print $2}' | wc -l"
     proc = subprocess.Popen(command, shell=True,stdout=subprocess.PIPE)
     return proc.communicate()[0].replace('\n', '')
+    
+def all_done():
+    if not os.listdir(packages_dir):
+        sleep_time=10
+        time.sleep(sleep_time)
+        cleanup()
+        subprocess.call(['/sbin/reboot'])
 
 def cleanup():
+    log_path = open(logfile, 'a')
     log.info('No more packages have been found to install, cleaning up.')
     # remove launchdaemon
     os.remove('/Library/LaunchDaemons/com.grahamgilbert.first-boot-pkg.plist')
@@ -59,6 +67,7 @@ First Boot Package Installer %s
                 log.info('Network connection is inactive, retrying...')
                 time_limit = time.sleep(plist_opts.get('SleepCount'))
     retry_limit = plist_opts.get('RetryCount')
+
     # if the packages dir isn't empty, loop over them
     if os.listdir(packages_dir):
         # We're installing, wait to see the output
@@ -92,15 +101,11 @@ First Boot Package Installer %s
                     os.remove(package_path)
                 except:
                     shutil.rmtree(package_path)
-                
-
-    # if there aren't any packages, remove everything we've put in
-    else:
-        sleep_time=1
-        cleanup()
+            all_done()                
     
     # We're done, reboot. Wait 20 seconds so the log window can be read.
     time.sleep(sleep_time)
+    all_done()
     subprocess.call(['/sbin/reboot'])
 
 if __name__ == '__main__':

--- a/Resources/first-boot
+++ b/Resources/first-boot
@@ -59,8 +59,7 @@ First Boot Package Installer %s
 ''') % time.strftime("%Y-%m-%d %H:%M:%S"))
     plist_opts = plistlib.readPlist(config_plist)
     # Detect new network hardware
-    command = "/usr/sbin/networksetup -detectnewhardware"
-    proc = subprocess.Popen(command, shell=True,stdout=subprocess.PIPE)
+    subprocess.call(['/usr/sbin/networksetup', '-detectnewhardware'])
     if plist_opts.get('Network') == True:
         # Check if the network is up
         while True:

--- a/Resources/first-boot
+++ b/Resources/first-boot
@@ -60,6 +60,7 @@ First Boot Package Installer %s
     plist_opts = plistlib.readPlist(config_plist)
     # Detect new network hardware
     command = "/usr/sbin/networksetup -detectnewhardware"
+    proc = subprocess.Popen(command, shell=True,stdout=subprocess.PIPE)
     if plist_opts.get('Network') == True:
         # Check if the network is up
         while True:

--- a/first-boot-pkg
+++ b/first-boot-pkg
@@ -12,6 +12,7 @@ import tempfile
 from time import localtime
 
 default_identifier = "com.grahamgilbert.first-boot-pkg"
+default_launchd = "com.grahamgilbert.first-boot-pkg"
 default_name = "first-boot.pkg"
 default_output_dir = os.getcwd()
 default_network = True
@@ -47,6 +48,10 @@ def main():
     o.add_option("-i", "--identifier", default=default_identifier,
         help=("Identifier of the built package. Defaults to '%s'. "
               % default_identifier))
+
+    o.add_option("--launchd", default=default_launchd,
+        help=("Name of launch daemon. Defaults to '%s'. "
+              % default_launchd))
     
     o.add_option("-n", "--name", 
         default=default_name,
@@ -106,7 +111,7 @@ def main():
     
     # Run over all of the packages and see if they look OK
     boot_packages = opts.packages or plist_opts.get('Packages')
-    print 'Valdating packages:'
+    print 'Validating packages:'
     print '----------------------------------------------------------------'
     for pkg in boot_packages:
         if (not pkg.endswith('.pkg') and not pkg.endswith('.mpkg')):
@@ -136,6 +141,13 @@ def main():
     if identifier == default_identifier and 'Identifier' in plist_opts:
         # Not passed one via the command line and the setting is in the plist
         identifier = plist_opts.get('Identifier')
+        
+    # LaunchDaemon
+    launchd = opts.launchd
+    launchdplist = launchd + '.plist'
+    if launchd == default_launchd and 'LaunchDaemonIdentifier' in plist_opts:
+        # Not passed one via the command line and the setting is in the plist
+        launchd = plist_opts.get('LaunchDaemonIdentifier')
     
     # Output 
     output_dir = opts.output_dir
@@ -199,6 +211,7 @@ def main():
     config_plist['Network'] = network
     config_plist['RetryCount'] = retry_count
     config_plist['SleepCount'] = sleep_count
+    config_plist['LaunchDaemon'] = launchdplist
     plistlib.writePlist(config_plist, os.path.join(root, firstboot_dir, 'config.plist'))
     
     # Copy the LaunchDaemon, LaunchAgent and LoginLog.app to the right places
@@ -207,18 +220,23 @@ def main():
     os.makedirs(launchDaemon_dir)
     shutil.copy(os.path.join(script_dir, 'Resources', 
     'com.grahamgilbert.first-boot-pkg.plist'), os.path.join(launchDaemon_dir, 
-    'com.grahamgilbert.first-boot-pkg.plist'))
-    # Set the permisisons
+    launchdplist))
+    # Fix plist Label
+    if "com.grahamgilbert.first-boot-pkg" in plistlib.readPlist(os.path.join(launchDaemon_dir, launchdplist))['Label']:
+        plistlabel = plistlib.readPlist(os.path.join(launchDaemon_dir, launchdplist))
+        plistlabel["Label"] = launchd
+        plistlib.writePlist(plistlabel, os.path.join(launchDaemon_dir, launchdplist))
+    # Set the permissions
     os.chmod(os.path.join(launchDaemon_dir, 
-    'com.grahamgilbert.first-boot-pkg.plist'), 0644)
+    launchdplist), 0644)
     os.chown(os.path.join(launchDaemon_dir, 
-    'com.grahamgilbert.first-boot-pkg.plist'), 0, 0)
+    launchdplist), 0, 0)
     
     launchAgent_dir = os.path.join(root, 'Library', 'LaunchAgents')
     os.makedirs(launchAgent_dir)
     shutil.copy(os.path.join(script_dir, 'Resources', 'se.gu.it.LoginLog.plist'), 
     os.path.join(launchAgent_dir, 'se.gu.it.LoginLog.plist'))
-    # Set the permisisons
+    # Set the permissions
     os.chmod(os.path.join(launchAgent_dir, 'se.gu.it.LoginLog.plist'), 0644)
     os.chown(os.path.join(launchAgent_dir, 'se.gu.it.LoginLog.plist'), 0, 0)
     
@@ -226,7 +244,7 @@ def main():
     os.makedirs(helperTools_dir)
     shutil.copytree(os.path.join(script_dir, 'Resources', 'LoginLog.app'), 
     os.path.join(helperTools_dir, 'LoginLog.app'))
-    # Set the permisisons
+    # Set the permissions
     for root_dir, dirs, files in os.walk(os.path.join(helperTools_dir, 'LoginLog.app')):  
       for momo in dirs:  
         os.chown(os.path.join(root_dir, momo), 0, 0)
@@ -237,7 +255,7 @@ def main():
     
     # copy the script
     shutil.copy(os.path.join(script_dir, 'Resources', 'first-boot'), os.path.join(install_dir, 'first-boot'))
-    # Set the permisisons
+    # Set the permissions
     os.chmod(os.path.join(install_dir, 'first-boot'), 0755)
     os.chown(os.path.join(install_dir, 'first-boot'), 0, 0)
     


### PR DESCRIPTION
1. Move over the all_done functions from Imagr to remove the secondary boot.
2. Added a optional LaunchDaemonIdentifier (--launchd) to create custom organizations (Add value in config.plist, Renames LaunchD, adds proper Label and removes properly when first-boot-pkg is done).
3. Fixes for typos in comments.
4. Added proper documentation.